### PR TITLE
Config Zabbix URL on Config.yaml

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,3 +1,4 @@
+zabbix_url: https://zabbix.example.com/zabbix
 endpoint: api.hipchat.com
 room: 12345
 token: abcdefgabcdefgabcdefgabcdefg

--- a/hipchat.rb
+++ b/hipchat.rb
@@ -7,7 +7,7 @@ alert_script = File.dirname(__FILE__) + "/notify.rb"
 
 # Load configuration
 config = YAML.load_file(File.join(File.dirname(__FILE__), 'config.yaml'))
-url = config['abbix_url']
+url = config['zabbix_url']
 
 YAML.load(ARGV[2]).each { |k, v| instance_variable_set("@" + k, v) }
 

--- a/hipchat.rb
+++ b/hipchat.rb
@@ -4,7 +4,10 @@ require 'rubygems'
 require 'yaml'
 
 alert_script = File.dirname(__FILE__) + "/notify.rb"
-url = "https://zabbix.example.com/zabbix"
+
+# Load configuration
+config = YAML.load_file(File.join(File.dirname(__FILE__), 'config.yaml'))
+url = config['abbix_url']
 
 YAML.load(ARGV[2]).each { |k, v| instance_variable_set("@" + k, v) }
 


### PR DESCRIPTION
The zabbix url is hard code on hipchat.rb, move it to config.yaml.
